### PR TITLE
Fix: Bug when polys have only vertex and texture data

### DIFF
--- a/vtkOBJWriter.cxx
+++ b/vtkOBJWriter.cxx
@@ -192,7 +192,7 @@ int vtkOBJWriter::RequestData(vtkInformation *vtkNotUsed(request),
           {
           if (tcoords)
             {
-            fout << static_cast<int>(indx[i])+idStart << " " << static_cast<int>(indx[i]) + idStart << " ";
+            fout << static_cast<int>(indx[i])+idStart << "/" << static_cast<int>(indx[i]) + idStart << " ";
             }
           else
             {


### PR DESCRIPTION
The OBJ face structure was invalid in the case when only vertex and texture data were present for a poly